### PR TITLE
Fix incorrect error message displayed: progressEvent

### DIFF
--- a/src/app/auth/pages/login-page/login-page.component.ts
+++ b/src/app/auth/pages/login-page/login-page.component.ts
@@ -69,7 +69,7 @@ export class LoginPageComponent implements OnInit {
 				this.messageService.add({
 					severity: 'error',
 					summary: 'Ups',
-					detail: `${error}`,
+					detail: error instanceof ProgressEvent ? 'Error de conexión' : `${error}`,
 				});
 				this.authService.isAuthenticated.next(AuthenticationStatus.notAuthenticated);
 				this.isLoading = false;


### PR DESCRIPTION
# Overview
Fix the incorrect errors message displayed on `login-page.component.ts`

## Summary
Added a validation to handle `HttpProgressEvent` response type when a connection error occurs. This validation was added in `login-page.component.ts` and helps to prevent an inconsistent user interaction with the toast error message. 

## Pending to be done
None